### PR TITLE
fix bug in search test, change the filtering method for searchByName

### DIFF
--- a/src/app/search_product_usecase_factory/SearchProductUseCaseFactory.java
+++ b/src/app/search_product_usecase_factory/SearchProductUseCaseFactory.java
@@ -152,8 +152,12 @@ public class SearchProductUseCaseFactory {
         ScheduleFactory scheduleFactory = new CommonScheduleFactory();
         ProductReadByNameDataAccessInterface productReadByNameDataAccessObject =
                 databaseProductReadByNameDataAccessObjectFactory.create(productFactory, scheduleFactory);
+        DataBaseProductReadAllDataAccessObjectFactoryInterface dataBaseProductReadAllDataAccessObjectFactoryInterface =
+                new DatabaseProductReadAllDataAccessObjectFactory();
+        ProductReadAllDataAccessInterface productReadAllDataAccessObeject =
+                dataBaseProductReadAllDataAccessObjectFactoryInterface.create(productFactory, scheduleFactory);
         SearchProductByNameInputBoundary searchProductByNameInteractor =
-                new SearchProductByNameInteractor(productReadByNameDataAccessObject,
+                new SearchProductByNameInteractor(productReadAllDataAccessObeject, productReadByNameDataAccessObject,
                         searchProductByNamePresenter);
         return new SearchProductByNameController(searchProductByNameInteractor);
     }

--- a/src/app/user_usecase_factory/ModifyProfileUseCaseFactory.java
+++ b/src/app/user_usecase_factory/ModifyProfileUseCaseFactory.java
@@ -157,8 +157,12 @@ public class ModifyProfileUseCaseFactory {
         ScheduleFactory scheduleFactory = new CommonScheduleFactory();
 
         ProductReadByNameDataAccessInterface productSearchByNameDAO = daoFactory.create(productFactory, scheduleFactory);
+        DataBaseProductReadAllDataAccessObjectFactoryInterface dataBaseProductReadAllDataAccessObjectFactoryInterface =
+                new DatabaseProductReadAllDataAccessObjectFactory();
+        ProductReadAllDataAccessInterface productReadAllDataAccessObeject =
+                dataBaseProductReadAllDataAccessObjectFactoryInterface.create(productFactory, scheduleFactory);
         SearchProductByNameOutputBoundary presenter = new SearchProductByNamePresenter(viewManagerModel, searchProductViewModel);
-        SearchProductByNameInputBoundary interactor = new SearchProductByNameInteractor(productSearchByNameDAO, presenter);
+        SearchProductByNameInputBoundary interactor = new SearchProductByNameInteractor(productReadAllDataAccessObeject, productSearchByNameDAO, presenter);
         return new SearchProductByNameController(interactor);
     }
 

--- a/src/app/user_usecase_factory/SignupUseCaseFactory.java
+++ b/src/app/user_usecase_factory/SignupUseCaseFactory.java
@@ -122,7 +122,11 @@ public class SignupUseCaseFactory {
         ProductFactory productFactory = new CommonProductFactory();
         ScheduleFactory scheduleFactory = new CommonScheduleFactory();
         ProductReadByNameDataAccessInterface productReadByNameDataAccessObject = databaseProductReadByNameDataAccessObjectFactory.create(productFactory, scheduleFactory);
-        SearchProductByNameInputBoundary interactor = new SearchProductByNameInteractor(productReadByNameDataAccessObject, presenter);
+        DataBaseProductReadAllDataAccessObjectFactoryInterface dataBaseProductReadAllDataAccessObjectFactoryInterface =
+                new DatabaseProductReadAllDataAccessObjectFactory();
+        ProductReadAllDataAccessInterface productReadAllDataAccessObeject =
+                dataBaseProductReadAllDataAccessObjectFactoryInterface.create(productFactory, scheduleFactory);
+        SearchProductByNameInputBoundary interactor = new SearchProductByNameInteractor(productReadAllDataAccessObeject, productReadByNameDataAccessObject, presenter);
         return new SearchProductByNameController(interactor);
     }
 

--- a/src/use_case/search_product/SearchProductByNameInteractor.java
+++ b/src/use_case/search_product/SearchProductByNameInteractor.java
@@ -1,5 +1,6 @@
 package use_case.search_product;
 
+import data_access.interfaces.product.ProductReadAllDataAccessInterface;
 import data_access.interfaces.product.ProductReadByNameDataAccessInterface;
 import entity.product.Product;
 import entity.user.User;
@@ -14,7 +15,7 @@ import java.util.ArrayList;
  */
 public class SearchProductByNameInteractor implements SearchProductByNameInputBoundary{
 
-//    final private ProductReadAllDataAccessInterface productReadAllDataAccessInterface;
+    final private ProductReadAllDataAccessInterface productReadAllDataAccessInterface;
     final private SearchProductByNameOutputBoundary searchProductByNamePresenter;
     private final ProductReadByNameDataAccessInterface productReadByNameDataAccessInterface;
 
@@ -22,37 +23,49 @@ public class SearchProductByNameInteractor implements SearchProductByNameInputBo
      * Constructs a SearchProductByNameInteractor with the specified data access interface and presenter.
      *
      * @param productReadByNameDataAccessInterface the data access interface to read products by name
+     * @param productReadAllDataAccessInterface the data access interface to read all products
      * @param searchProductByNamePresenter the output boundary to handle the output data
      */
-    public SearchProductByNameInteractor( ProductReadByNameDataAccessInterface productReadByNameDataAccessInterface, SearchProductByNameOutputBoundary searchProductByNamePresenter) {
-//        this.productReadAllDataAccessInterface = productReadAllDataAccessInterface;
+    public SearchProductByNameInteractor(ProductReadAllDataAccessInterface productReadAllDataAccessInterface, ProductReadByNameDataAccessInterface productReadByNameDataAccessInterface, SearchProductByNameOutputBoundary searchProductByNamePresenter) {
+        this.productReadAllDataAccessInterface = productReadAllDataAccessInterface;
         this.searchProductByNamePresenter = searchProductByNamePresenter;
         this.productReadByNameDataAccessInterface = productReadByNameDataAccessInterface;
     }
 
     @Override
     public void execute(SearchProductByNameInputData inputData) throws SQLException, IOException {
-        User user = inputData.getUser();
-        ArrayList<Product> products = productReadByNameDataAccessInterface.getProductByName(inputData.getProductName());
 
-//        String searchTerm = inputData.getProductName().toLowerCase();
-//        ArrayList<Product> allProducts = productReadAllDataAccessInterface.getAllProducts();
-//
-//        // Filter products based on whether their titles/names contain the search term
-//        ArrayList<Product> matchingProducts = new ArrayList<>();
-//        for (Product product : allProducts) {
-//            if (product.getTitle().toLowerCase().contains(searchTerm)) {
-//                matchingProducts.add(product);
-//            }
-//        }
-        ArrayList<Product> searchedProducts = new ArrayList<>();
-        for (Product product : products) {
-            if (product.getState() == 0) {
-                searchedProducts.add(product);
+        User user = inputData.getUser();
+        String searchTerm = inputData.getProductName().toLowerCase(); // Convert search term to lower case for case-insensitive search
+
+        // Get exact match products
+        ArrayList<Product> exactMatchProducts = productReadByNameDataAccessInterface.getProductByName(inputData.getProductName());
+
+        // Get all products
+        ArrayList<Product> allProducts = productReadAllDataAccessInterface.getAllProducts();
+
+        // Filter products based on whether their titles/names contain the search term
+        ArrayList<Product> matchingProducts = new ArrayList<>();
+        for (Product product : allProducts) {
+            if (!exactMatchProducts.contains(product) && product.getTitle().toLowerCase().contains(searchTerm)) {
+                matchingProducts.add(product);
             }
         }
 
-        SearchProductByNameOutputData outputData = new SearchProductByNameOutputData(user, searchedProducts);
+        // Combine exact matches and matching products, ensuring exact matches come first
+        ArrayList<Product> searchedProducts = new ArrayList<>(exactMatchProducts);
+        searchedProducts.addAll(matchingProducts);
+
+        // Filter products that have state 0
+        ArrayList<Product> outputProducts = new ArrayList<>();
+        for (Product product : searchedProducts) {
+            if (product.getState() == 0) {
+                outputProducts.add(product);
+            }
+        }
+
+
+        SearchProductByNameOutputData outputData = new SearchProductByNameOutputData(user, outputProducts);
         searchProductByNamePresenter.prepareSuccessfulView(outputData);
     }
 }

--- a/test/use_case/search_product/GetSearchViewInteractorTest.java
+++ b/test/use_case/search_product/GetSearchViewInteractorTest.java
@@ -69,7 +69,7 @@ class GetSearchViewInteractorTest {
 
         // product2 is a product that is not on sale, so its state is non-zero
 
-        Image image2 = ImageIO.read(new File("src.pic.testpic2.png"));
+        Image image2 = ImageIO.read(new File("src/pic/testpic2.png"));
         String description2 = "This is a description";
         String title2 = "This is a title ";
         float price2 = 2;
@@ -108,7 +108,25 @@ class GetSearchViewInteractorTest {
                 ArrayList<Product> actualProducts = getSearchViewOutputData.getAllProducts();
                 ArrayList<Product> expectedProducts = new ArrayList<>();
                 expectedProducts.add(product1);
-                assertEquals(expectedProducts, actualProducts); // only product1 should be displayed.
+                assertEquals(expectedProducts.size(), actualProducts.size());
+                for (int i = 0; i < expectedProducts.size(); i++) {
+                    Product expectedProduct = expectedProducts.get(i);
+                    Product actualProduct = actualProducts.get(i);
+                    assertEquals(expectedProduct.getImage(), actualProduct.getImage());
+                    assertEquals(expectedProduct.getDescription(), actualProduct.getDescription());
+                    assertEquals(expectedProduct.getTitle(), actualProduct.getTitle());
+                    assertEquals(expectedProduct.getPrice(), actualProduct.getPrice(), 0);
+                    assertEquals(expectedProduct.getState(), actualProduct.getState());
+                    assertEquals(expectedProduct.getRating(), actualProduct.getRating(), 0);
+                    assertEquals(expectedProduct.geteTransferEmail(), actualProduct.geteTransferEmail());
+                    assertEquals(expectedProduct.getSellerStudentNumber(), actualProduct.getSellerStudentNumber());
+                    assertEquals(expectedProduct.getAddress(), actualProduct.getAddress());
+                    assertEquals(expectedProduct.getListTags(), actualProduct.getListTags());
+                    assertEquals(expectedProduct.getProductID(), actualProduct.getProductID());
+                    assertEquals(expectedProduct.getSchedule().getSellerTime(), actualProduct.getSchedule().getSellerTime());
+                    assertEquals(expectedProduct.getSchedule().getBuyerTime(), actualProduct.getSchedule().getBuyerTime());
+                }
+                // only product1 should be displayed.
             }
         };
         ProductReadAllDataAccessInterface inMemoryProductReadAllDataAccessObject =

--- a/test/use_case/search_product/SearchProductByNameInteractorTest.java
+++ b/test/use_case/search_product/SearchProductByNameInteractorTest.java
@@ -1,6 +1,8 @@
 package use_case.search_product;
 
+import data_access.in_memory.product.InMemoryProductReadAllDataAccessObject;
 import data_access.in_memory.product.InMemoryProductReadByNameDataAccessObject;
+import data_access.interfaces.product.ProductReadAllDataAccessInterface;
 import data_access.interfaces.product.ProductReadByNameDataAccessInterface;
 import entity.product.CommonProductFactory;
 import entity.product.Product;
@@ -32,6 +34,7 @@ class SearchProductByNameInteractorTest {
     private Product product1;
     private Product product2;
     private Product product3;
+    private Product product4;
 
     @BeforeEach
     void setUp() throws IOException {
@@ -73,7 +76,7 @@ class SearchProductByNameInteractorTest {
 
         // product2 is a product that does not contain the productName we want to search in its title/name and is on sale
 
-        Image image2 = ImageIO.read(new File("src.pic.testpic2.png"));
+        Image image2 = ImageIO.read(new File("src/pic/testpic2.png"));
         String description2 = "This is a description";
         String title2 = "bcd";
         float price2 = 2;
@@ -96,7 +99,7 @@ class SearchProductByNameInteractorTest {
         products.add(product2);
 
         // product3 is a product that contains the productName we want to search in its title/name but is not on sale.
-        Image image3 = ImageIO.read(new File("src.pic.testpic2.png"));
+        Image image3 = ImageIO.read(new File("src/pic/testpic3.png"));
         String description3 = "This is a description";
         String title3 = "abc";
         float price3 = 2;
@@ -117,6 +120,28 @@ class SearchProductByNameInteractorTest {
         );
 
         products.add(product3);
+
+        // product4 is a product that has the exact name we want to search and is on sale
+        Image image4 = ImageIO.read(new File("src/pic/testpic4.png"));
+        String description4 = "This is a description";
+        String title4 = "a";
+        float price4 = 3;
+        Integer rating4 = 0;
+        int state4 = 0;
+        String eTransferEmail4 = "example@email.com";
+        String sellerStudentNumber4 = "1111111111";
+        String address4 = "BA 3175";
+        ArrayList<String> listTags4 = new ArrayList<>();
+        listTags4.add("Tag 1");
+        String productID4 = "id_4";
+        LocalDateTime buyerTime4 = null;
+        ArrayList<LocalDateTime> sellerTime4 = new ArrayList<>();
+        Schedule schedule4 = scheduleFactory.createSchedule(buyerTime4, sellerTime4);
+        product4 = productFactory.createProduct(image4, description4, title4, price4,
+                state4, rating4, eTransferEmail4, sellerStudentNumber4, address4,
+                listTags4, productID4, schedule4);
+
+        products.add(product4);
     }
 
     @AfterEach
@@ -133,14 +158,32 @@ class SearchProductByNameInteractorTest {
 
                 ArrayList<Product> actualProducts = searchProductByNameOutputData.getProducts();
                 ArrayList<Product> expectedProducts = new ArrayList<>();
-                expectedProducts.add(product1); // only product1 should be displayed.
-                assertEquals(expectedProducts, actualProducts);
+                expectedProducts.add(product4); // Exact match product should be first
+                expectedProducts.add(product1); // Contains the search term
+                for (int i = 0; i < expectedProducts.size(); i++) {
+                    Product expectedProduct = expectedProducts.get(i);
+                    Product actualProduct = actualProducts.get(i);
+                    assertEquals(expectedProduct.getImage(), actualProduct.getImage());
+                    assertEquals(expectedProduct.getDescription(), actualProduct.getDescription());
+                    assertEquals(expectedProduct.getTitle(), actualProduct.getTitle());
+                    assertEquals(expectedProduct.getPrice(), actualProduct.getPrice());
+                    assertEquals(expectedProduct.getState(), actualProduct.getState());
+                    assertEquals(expectedProduct.getRating(), actualProduct.getRating());
+                    assertEquals(expectedProduct.geteTransferEmail(), actualProduct.geteTransferEmail());
+                    assertEquals(expectedProduct.getSellerStudentNumber(), actualProduct.getSellerStudentNumber());
+                    assertEquals(expectedProduct.getAddress(), actualProduct.getAddress());
+                    assertEquals(expectedProduct.getListTags(), actualProduct.getListTags());
+                    assertEquals(expectedProduct.getProductID(), actualProduct.getProductID());
+                    assertEquals(expectedProduct.getSchedule().getSellerTime(), actualProduct.getSchedule().getSellerTime());
+                    assertEquals(expectedProduct.getSchedule().getBuyerTime(), actualProduct.getSchedule().getBuyerTime());
+                }
             }
         };
         ProductReadByNameDataAccessInterface inMemoryProductReadByNameDataAccessObject = new InMemoryProductReadByNameDataAccessObject(products);
+        ProductReadAllDataAccessInterface inMemoryProductReadAllDataAccessObject = new InMemoryProductReadAllDataAccessObject(products);
         SearchProductByNameInputData inputData = new SearchProductByNameInputData(user, productName);
         SearchProductByNameInteractor interactor =
-                new SearchProductByNameInteractor(inMemoryProductReadByNameDataAccessObject, searchProductByNameOutputBoundary);
+                new SearchProductByNameInteractor(inMemoryProductReadAllDataAccessObject, inMemoryProductReadByNameDataAccessObject, searchProductByNameOutputBoundary);
         interactor.execute(inputData);
     }
 }

--- a/test/use_case/search_product/SearchProductByTagInteractorTest.java
+++ b/test/use_case/search_product/SearchProductByTagInteractorTest.java
@@ -73,7 +73,7 @@ class SearchProductByTagInteractorTest {
 
         // product2 is a product that does not have the tag we want to search and is on sale.
 
-        Image image2 = ImageIO.read(new File("src.pic.testpic2.png"));
+        Image image2 = ImageIO.read(new File("src/pic/testpic2.png"));
         String description2 = "This is a description";
         String title2 = "bcd";
         float price2 = 2;
@@ -96,7 +96,7 @@ class SearchProductByTagInteractorTest {
         products.add(product2);
 
         // product3 is a product that has the tag we want to search but is not on sale.
-        Image image3 = ImageIO.read(new File("src.pic.testpic2.png"));
+        Image image3 = ImageIO.read(new File("src/pic/testpic3.png"));
         String description3 = "This is a description";
         String title3 = "abc";
         float price3 = 2;
@@ -134,7 +134,23 @@ class SearchProductByTagInteractorTest {
                 ArrayList<Product> actualProducts = searchProductByTagOutputData.getProducts();
                 ArrayList<Product> expectedProducts = new ArrayList<>();
                 expectedProducts.add(product1); // only product1 should be displayed.
-                assertEquals(expectedProducts, actualProducts);
+                for (int i = 0; i < expectedProducts.size(); i++) {
+                    Product expectedProduct = expectedProducts.get(i);
+                    Product actualProduct = actualProducts.get(i);
+                    assertEquals(expectedProduct.getImage(), actualProduct.getImage());
+                    assertEquals(expectedProduct.getDescription(), actualProduct.getDescription());
+                    assertEquals(expectedProduct.getTitle(), actualProduct.getTitle());
+                    assertEquals(expectedProduct.getPrice(), actualProduct.getPrice());
+                    assertEquals(expectedProduct.getState(), actualProduct.getState());
+                    assertEquals(expectedProduct.getRating(), actualProduct.getRating());
+                    assertEquals(expectedProduct.geteTransferEmail(), actualProduct.geteTransferEmail());
+                    assertEquals(expectedProduct.getSellerStudentNumber(), actualProduct.getSellerStudentNumber());
+                    assertEquals(expectedProduct.getAddress(), actualProduct.getAddress());
+                    assertEquals(expectedProduct.getListTags(), actualProduct.getListTags());
+                    assertEquals(expectedProduct.getProductID(), actualProduct.getProductID());
+                    assertEquals(expectedProduct.getSchedule().getSellerTime(), actualProduct.getSchedule().getSellerTime());
+                    assertEquals(expectedProduct.getSchedule().getBuyerTime(), actualProduct.getSchedule().getBuyerTime());
+                }
             }
         };
         ProductReadByTagDataAccessInterface inMemoryProductReadByTagDataAccessObject =


### PR DESCRIPTION
Updated SearchProductByNameInteractor to include both exact match and partial match products in the search results. Exact match products are listed first, followed by products whose names contain the search term, ensuring case-insensitive comparison.
